### PR TITLE
Prepare initial release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,7 @@
+# Release notes
+
+All notable changes to this project will be documented in this file.
+
+## 0.1.0
+
+- Initial version based on backoff from kcas (@lyrm, @polytypic)

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,0 +1,11 @@
+### Formatting
+
+This project uses [ocamlformat](https://github.com/ocaml-ppx/ocamlformat) (for
+OCaml) and [prettier](https://prettier.io/) (for Markdown).
+
+### To make a new release
+
+1. Update [CHANGES.md](CHANGES.md).
+2. Run `dune-release tag VERSION` to create a tag for the new `VERSION`.
+3. Run `dune-release` to publish the new `VERSION`.
+4. Run `./update-gh-pages-for-tag VERSION` to update the online documentation.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[API reference](TODO)
+[API reference](https://ocaml-multicore.github.io/backoff/doc/backoff/Backoff/index.html)
 
 # backoff - exponential backoff mechanism
 

--- a/update-gh-pages-for-tag
+++ b/update-gh-pages-for-tag
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+set -xeuo pipefail
+
+TMP=tmp
+NAME=backoff
+MAIN=doc
+GIT="git@github.com:ocaml-multicore/$NAME.git"
+DOC="_build/default/_doc/_html"
+GH_PAGES=gh-pages
+
+TAG="$1"
+
+if ! [ -e $NAME.opam ] || [ $# -ne 1 ] || \
+     { [ "$TAG" != main ] && ! [ "$(git tag -l "$TAG")" ]; }; then
+  CMD="${0##*/}"
+  cat << EOF
+Usage: $CMD tag-name-or-main
+
+This script
+- clones the repository into a temporary directory ($TMP/$NAME),
+- builds the documentation for the specified tag or main,
+- updates $GH_PAGES branch with the documentation in directory for the tag,
+- prompts whether to also update the main documentation in $MAIN directory, and
+- prompts whether to push changes to $GH_PAGES.
+
+EOF
+  exit 1
+fi
+
+mkdir $TMP
+cd $TMP
+
+git clone $GIT
+cd $NAME
+
+git checkout "$TAG"
+dune build @doc --root=.
+
+git checkout $GH_PAGES
+if [ "$TAG" != main ]; then
+  echo "Updating the $TAG doc."
+  if [ -e "$TAG" ]; then
+    git rm -rf "$TAG"
+  fi
+  cp -r $DOC "$TAG"
+  git add "$TAG"
+fi
+
+read -p "Update the main doc? (y/N) " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+  if [ -e $MAIN ]; then
+    git rm -rf $MAIN
+  fi
+  cp -r $DOC $MAIN
+  git add $MAIN
+else
+  echo "Skipped main doc update."
+fi
+
+git commit -m "Update $NAME doc for $TAG"
+
+read -p "Push changes to $GH_PAGES? (y/N) " -n 1 -r
+echo
+if ! [[ $REPLY =~ ^[Yy]$ ]]; then
+  echo "Leaving $TMP for you to examine."
+  exit 1
+fi
+
+git push
+
+cd ..
+cd ..
+rm -rf $TMP


### PR DESCRIPTION
This PR:
*  Adds `CHANGES.md` with notes for the initial version
* Adds `HACKING.md` with some minimal instructions on formatting and release instructions for maintainers
* Adds `update-gh-pages-for-tag` script which is a script developed originally for kcas (and then used in many other repositories under ocaml-multicore) to help maintain documentation for multiple versions of the library on gh-pages
* Updates the link to [API reference](https://ocaml-multicore.github.io/backoff/doc/backoff/Backoff/index.html) in the `README.md` to point directly to the `Backoff` module page