### PR TITLE
Add `LICENSE.md`

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,16 @@
+Copyright (c) 2015, Théo Laurent <theo.laurent@ens.fr>
+Copyright (c) 2016, KC Sivaramakrishnan <kc@kcsrk.info>
+Copyright (c) 2021, Sudha Parimala <sudharg247@gmail.com>
+Copyright (c) 2023, Vesa Karvonen <vesa.a.j.k@gmail.com>
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.


### PR DESCRIPTION
Linting done by `dune-release` requires a license.

The copyright holders are from the `backoff.ml` and `backoff.mli` files.