### PR TITLE
Port to 4.12 and tweak the implementation for size

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,4 +1,4 @@
-name: build-and-test
+name: ci
 
 on:
   pull_request:
@@ -7,20 +7,28 @@ on:
       - main
 
 jobs:
-  build-windows:
+  test-on-windows:
+    strategy:
+      fail-fast: false
+      matrix:
+        ocaml-compiler:
+          - ocaml.5.0.0,ocaml-option-mingw
+          - ocaml.5.1.1,ocaml-option-mingw
+          - ocaml.5.2.0,ocaml-option-mingw
+
     runs-on: windows-latest
 
     steps:
-      - name: Checkout code
+      - name: Check out code
         uses: actions/checkout@v3
 
-      - name: Set-up OCaml
-        uses: ocaml/setup-ocaml@v2
+      - name: Set up OCaml
+        uses: ocaml/setup-ocaml@v3
         with:
-          ocaml-compiler: ocaml.5.0.0,ocaml-option-mingw
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
           opam-repositories: |
             dra27: https://github.com/dra27/opam-repository.git#windows-5.0
-            default: https://github.com/fdopen/opam-repository-mingw.git#opam2
+            default: https://github.com/ocaml-opam/opam-repository-mingw.git#sunset
             standard: https://github.com/ocaml/opam-repository.git
 
       - name: Install dependencies

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,2 +1,2 @@
 profile = default
-version = 0.26.0
+version = 0.26.2

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
-# Release notes
+## 0.1.1
 
-All notable changes to this project will be documented in this file.
+- Ported to 4.12 and optimized for size (@polytypic)
 
 ## 0.1.0
 

--- a/backoff.opam
+++ b/backoff.opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/ocaml-multicore/backoff"
 bug-reports: "https://github.com/ocaml-multicore/backoff/issues"
 depends: [
   "dune" {>= "3.3"}
-  "ocaml" {>= "4.13"}
+  "ocaml" {>= "4.12"}
   "alcotest" {>= "1.7.0" & with-test}
   "domain_shims" {>= "0.1.0" & with-test}
   "odoc" {with-doc}

--- a/dune-project
+++ b/dune-project
@@ -10,6 +10,6 @@
  (name backoff)
  (synopsis "Exponential backoff mechanism for OCaml")
  (depends
-  (ocaml (>= 4.13))
+  (ocaml (>= 4.12))
   (alcotest (and (>= 1.7.0) :with-test))
   (domain_shims (and (>= 0.1.0) :with-test))))


### PR DESCRIPTION
Here is [a Compiler Explorer link with the changed implementation from this PR](https://ocaml.godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXAEx8BBAKoBnTAAUAHpwAMvAFYTStJg1CpRLWqSX1kBPAMqN0AYVS0AriwYhJAFlIOAMngMmABy7gBGmMQgAMwAHKQADqgKhLYMzm4eXr7JqTYCgcFhLJHR8RaYVgUMQgRMxASZ7p4%2BldXpdQ0ERaERUbEJCvWNzdltw929JWWDAJQWqK7EyOwcBACeiZgA1AQ7AKQxACI7QQQHGgCCl1f0%2B6lG9AD6LEwKANaHJzsAQqguAB0RGe5x2EGOqDeQUBxEwaBYbAYWHQz3QUKYQWeaFcgnBc2%2Bpy4BIAtDsuLd7jtwoQFISdgBWSmYfZvVTPADumIIz1oqGA9JiGnBACpDgzfgAlQzoliAmkEBQHBmnOEEZYMOlCnbEGVQ6m0wE7EVzZms95fI6nCBcHa0BS0A2K0nk25mnbIOFMAi7I4AMQgfI5UU53N5/Pp3gJ/ogrkS22IocI4YFVvJAHYCRBoydbjsdu8lI1wXn8zthUdHGmgyGucm%2BcBS/mDpIAGwt1t21DBxN1nkN75Vn5xhNJ/v8puHNsdnYj2thgeVtNsscp00xX6l2Px%2Bf1iP2x0QBV0sWSOam675vnEcE13sL/cOp0KAnXrs91cNt3XKnAFnPOd7z3AVwiYZAPlQKgqHpUDwMg6D7RvI9aWNHYz3dP9xw/PsU2pMCIKg%2Bkj3w%2BC7QUG9j1fGUdjeT4MP/HCB1ggjoLTZjSIMZEaItb87hZHVMCUfZ2MIq1SypO9PwjNNMPDbCHxAkjCKCUsRIQ6jaAYVBzU%2BLsb0kxiJ2ud0BFWPC4NE3NLztfj9jTaVkSheUUOzM4GHE/jDNTH5ZK88yWLcjz9hw2jLR%2BG0yMdLyXVtFTrKpOyfjhaCIH2Tj0B2EKLTtajHmAF5QoJOKrnzDkEDoXYKxiIdTjAMB9nRSdIWhBhAWQRJXGeOEDFUfEjk3az832EA0zq/YyQpDdS3RYJ%2BqC2cdyA8dvNOWTAKkxSLOg4qr08hT6V8/a1MC%2BL%2BOCVQeT8tMrskX4/gBWhgVQUE8QgK7qoW0dopOkr/NIskbru87LoU3iqSwKgmFcWhEtOT1MG9XZsw4BZaE4BleE8bheFQTgAHlHFYR0FCWFZfUkGIeFIAhNBRhYPhABkNEBDQNAZOIGVbdMAE4NEkLgGW5/ROG8THadIXGOF4BQQA0anaYWOBYCQBFEgqsgKAgVX1ZAEwiYZSRWb4OgfWIGWj3FmlmGIDZOCpq2Gg2PHwm0eEaex0gESRAg8YYWhbY4LRSCwcJXGAQnaHtO3eCwN4njWIP8Dhaw8AAN0E8XMFUeFXB9aPyEEKpxdoPBwl1G3nCwcWCGIPAWHz9PiHCFJMGOTA4/yoJQEDlG%2BAMYAFAANTwTAOTx7Ysap/hBBEMR2C4Xxp/kJQ1HF3QuH0QxjFMcwS/CGXIAWVBEhqGWpYlxva6wA/s3aN30nsZExk8Sm/GRaZ%2BmiKQ5byNIBGf2IG9f41A/qUAY3874pwEF0UYLgWiAMgTUGBPQgh9DAV/Q2FgRhNDgdkV%2BkxGigNmN/BYJNlirAkKjdGYse4S04DsVQcRWwklbN4HYeszDH32AyQEkgWbglwIQEgU5KZzF4O7LQ55SAIARlgaIt8GbeG5oCbm3NvALxiIbbm6Y4jqI3mjDgotSBYyDpLaWst5Y9ykQYyQNDTGcHEQrBYjdUh2G8EAA%3D%3D).

The changes reduce the code size and also reduce the number of words allocated from the stack.  These are unlikely to give measurable performance improvements.  The real reason for looking into this is to port this to 4.12.  There is some demand among OCaml users to have various libraries using backoff to work on older compilers.  OCaml 4.12 introduced atomics, so going below that is probably not worth the effort.